### PR TITLE
Use NUL instead of /dev/null in Windows.

### DIFF
--- a/src/otfm.ml
+++ b/src/otfm.ml
@@ -7,7 +7,8 @@
 
 
 let debugfmt =
-  Format.formatter_of_out_channel (open_out "/dev/null")
+  let dev_null = if Sys.os_type = "Win32" then "NUL" else "/dev/null" in
+  Format.formatter_of_out_channel (open_out dev_null)
 
 let fmtgen  = debugfmt
 let fmtGSUB = debugfmt


### PR DESCRIPTION
This is necessary to prevent the error below in Windows:

```
C:\Users\qnighy\SATySFi>satysfi
Uncaught exception:

  (Sys_error "/dev/null: No such file or directory")

Raised by primitive operation at file "pervasives.ml", line 315, characters 29-55
Called from file "pervasives.ml", line 320, characters 2-74
```