### PR TITLE
support subset embedding of OpenType CFF fonts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PREFIX=/usr/local/bin
-OCB=ocamlbuild -use-ocamlfind
+OCB=ocamlbuild -use-ocamlfind -pkgs str
 
 all: otf gsub cff examples subset
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PREFIX=/usr/local/bin
-OCB=ocamlbuild -use-ocamlfind -pkgs str
+OCB=ocamlbuild -use-ocamlfind
 
 all: otf gsub cff examples subset
 

--- a/_tags
+++ b/_tags
@@ -1,3 +1,3 @@
-true : bin_annot, safe_string, package(bytes uchar result uutf)
+true : bin_annot, safe_string, package(bytes uchar result uutf str)
 <src> : include
 <test> : include

--- a/src/otfSubset.ml
+++ b/src/otfSubset.ml
@@ -32,13 +32,13 @@ let make d cffinfo gidlst =
       in
       encf rglst >>= fun (info, gdata) ->
       let rawtbl_hmtx = info.Otfm.Encode.hmtx in
-      let (glyph_tables, maxp_version) =
+      let (glyph_tables, oltype) =
         match gdata with
         | TrueTypeGlyph(rawtbl_glyf, rawtbl_loca) ->
-            ([rawtbl_glyf; rawtbl_loca], Otfm.Encode.TrueTypeVersion)
+            ([rawtbl_glyf; rawtbl_loca], Otfm.Encode.TrueTypeOutline)
 
         | CFFGlyph(rawtbl_cff) ->
-            ([rawtbl_cff]              , Otfm.Encode.CFFVersion)
+            ([rawtbl_cff]              , Otfm.Encode.CFFData)
       in
 
     (* -- updates the 'maxp' table -- *)
@@ -48,7 +48,7 @@ let make d cffinfo gidlst =
           Otfm.maxp_num_glyphs = info.Otfm.Encode.number_of_glyphs;
         }
       in
-      Otfm.Encode.maxp maxp_version maxpnew >>= fun rawtbl_maxp ->
+      Otfm.Encode.maxp oltype maxpnew >>= fun rawtbl_maxp ->
 
     (* -- updates the 'head' table -- *)
       Otfm.head d >>= fun head ->
@@ -87,5 +87,5 @@ let make d cffinfo gidlst =
           rawtbl_hmtx;
         ]
       in
-      Otfm.Encode.make_font_file (common_tables @ glyph_tables) >>= fun data ->
+      Otfm.Encode.make_font_file oltype (common_tables @ glyph_tables) >>= fun data ->
       return (Some(data))

--- a/src/otfSubset.ml
+++ b/src/otfSubset.ml
@@ -12,12 +12,12 @@ let reverse_some opts =
   aux [] opts
 
 
-let make d gidlst =
+let make d cffinfo gidlst =
 
 (* -- generates the subset of the glyph table -- *)
   gidlst |> List.fold_left (fun res gid ->
     res >>= fun rgacc ->
-    Otfm.get_raw_glyph d gid >>= fun rg ->
+    Otfm.get_raw_glyph d cffinfo gid >>= fun rg ->
     return (rg :: rgacc)
   ) (return []) >>= fun rgacc ->
   match reverse_some rgacc with
@@ -25,10 +25,20 @@ let make d gidlst =
       return None
 
   | Some(rglst) ->
-      Otfm.Encode.truetype_outline_tables rglst >>= fun info ->
+      let encf =
+        match cffinfo with
+        | None          -> Otfm.Encode.truetype_outline_tables
+        | Some(cffinfo) -> Otfm.Encode.cff_outline_tables d cffinfo
+      in
+      encf rglst >>= fun (info, gdata) ->
       let rawtbl_hmtx = info.Otfm.Encode.hmtx in
-      let rawtbl_glyf = info.Otfm.Encode.glyf in
-      let rawtbl_loca = info.Otfm.Encode.loca in
+      let glyph_tables =
+        match gdata with
+        | TrueTypeGlyph(rawtbl_glyf, rawtbl_loca) ->
+            [rawtbl_glyf; rawtbl_loca]
+        | CFFGlyph(rawtbl_cff) ->
+            [rawtbl_cff]
+      in
 
     (* -- updates the 'maxp' table -- *)
       Otfm.maxp d >>= fun maxp ->
@@ -67,13 +77,14 @@ let make d gidlst =
     (* -- 'cmap' table -- *)
       Otfm.Encode.empty_cmap () >>= fun rawtbl_cmap ->
 
-      Otfm.Encode.make_font_file [
-        rawtbl_cmap;
-        rawtbl_head;
-        rawtbl_hhea;
-        rawtbl_maxp;
-        rawtbl_hmtx;
-        rawtbl_loca;
-        rawtbl_glyf;
-      ] >>= fun data ->
+      let common_tables =
+        [
+          rawtbl_cmap;
+          rawtbl_head;
+          rawtbl_hhea;
+          rawtbl_maxp;
+          rawtbl_hmtx;
+        ]
+      in
+      Otfm.Encode.make_font_file (common_tables @ glyph_tables) >>= fun data ->
       return (Some(data))

--- a/src/otfSubset.ml
+++ b/src/otfSubset.ml
@@ -32,12 +32,13 @@ let make d cffinfo gidlst =
       in
       encf rglst >>= fun (info, gdata) ->
       let rawtbl_hmtx = info.Otfm.Encode.hmtx in
-      let glyph_tables =
+      let (glyph_tables, maxp_version) =
         match gdata with
         | TrueTypeGlyph(rawtbl_glyf, rawtbl_loca) ->
-            [rawtbl_glyf; rawtbl_loca]
+            ([rawtbl_glyf; rawtbl_loca], Otfm.Encode.TrueTypeVersion)
+
         | CFFGlyph(rawtbl_cff) ->
-            [rawtbl_cff]
+            ([rawtbl_cff]              , Otfm.Encode.CFFVersion)
       in
 
     (* -- updates the 'maxp' table -- *)
@@ -47,7 +48,7 @@ let make d cffinfo gidlst =
           Otfm.maxp_num_glyphs = info.Otfm.Encode.number_of_glyphs;
         }
       in
-      Otfm.Encode.maxp maxpnew >>= fun rawtbl_maxp ->
+      Otfm.Encode.maxp maxp_version maxpnew >>= fun rawtbl_maxp ->
 
     (* -- updates the 'head' table -- *)
       Otfm.head d >>= fun head ->

--- a/src/otfSubset.mli
+++ b/src/otfSubset.mli
@@ -1,2 +1,2 @@
 
-val make : Otfm.decoder -> Otfm.glyph_id list -> (string option, Otfm.error) result
+val make : Otfm.decoder -> Otfm.cff_info option -> Otfm.glyph_id list -> (string option, Otfm.error) result

--- a/src/otfm.ml
+++ b/src/otfm.ml
@@ -5909,10 +5909,10 @@ module Encode = struct
     | Internal(e) -> err e
 
 
-  let enc_charstring_data d offset_CFF enc csd =
+  let enc_charstring_data d enc csd =
     match csd with
     | CharStringData(offset, len) ->
-        enc_copy_direct d enc (offset + offset_CFF) len
+        enc_copy_direct d enc offset len
 
 
   let enc_cff_table (d : decoder) (enc : encoder) (cfffirst : cff_first) (charstrings : charstring_raw array) (fdselect : (int array) option) =
@@ -6023,7 +6023,7 @@ module Encode = struct
     (* String INDEX *)
     enc_index           enc enc_direct (make_elem_len_pair_of_array String.length stridx) >>= fun () ->
     (* Global Subr INDEX *)
-    enc_index           enc (enc_charstring_data d offset_CFF)
+    enc_index           enc (enc_charstring_data d)
                           (make_elem_len_pair_of_array get_charstring_length gsubridx) >>= fun () ->
     (* FDSelect (CIDFonts only) *)
     ( match fdselect with
@@ -6038,7 +6038,7 @@ module Encode = struct
     (* Private DICT *)
     enc_array enc (enc_dict true) privarray >>= fun () ->
     (* Local Subr INDEX *)
-    enc_array enc (fun enc idx -> enc_index enc (enc_charstring_data d offset_CFF)
+    enc_array enc (fun enc idx -> enc_index enc (enc_charstring_data d)
                     (make_elem_len_pair_of_array get_charstring_length idx)) lsubrarray
 
 

--- a/src/otfm.ml
+++ b/src/otfm.ml
@@ -1298,7 +1298,7 @@ let maxp d =
   init_decoder d >>=
   seek_required_table Tag.maxp d >>= fun () ->
   d_uint32 d >>= fun version ->
-  confirm (version = !%% 0x00010000L) (e_version d version) >>= fun () ->
+    confirm (version = !%% 0x00010000L) (e_version d version) >>= fun () ->
   d_uint16 d >>= fun maxp_num_glyphs ->
   d_uint16 d >>= fun maxp_max_points ->
   d_uint16 d >>= fun maxp_max_contours ->
@@ -5363,12 +5363,12 @@ module Encode = struct
         enc_uint8 enc (i + 139)
 
     | Value(Integer(i)) when i |> is_in_range 108 1131 ->
-        enc_uint8 enc (i / 256 + 247) >>= fun () ->
-        enc_uint8 enc (i mod 256 - 108)
+        enc_uint8 enc (247 + ((i - 108) / 256)) >>= fun () ->
+        enc_uint8 enc ((i - 108) mod 256)
 
     | Value(Integer(i)) when i |> is_in_range (-1131) (-108) ->
-        enc_uint8 enc (-(i / 256 - 251)) >>= fun () ->
-        enc_uint8 enc (-(i mod 256 + 108))
+        enc_uint8 enc (254 - ((i + 1131) / 256)) >>= fun () ->
+        enc_uint8 enc (255 - ((i + 1131) mod 256))
 
     | Value(Integer(i)) when i |> is_in_range (-32768) 32767 ->
         enc_uint8 enc 28 >>= fun () ->

--- a/src/otfm.ml
+++ b/src/otfm.ml
@@ -5152,7 +5152,8 @@ module Encode = struct
 
   let enc_uint8 enc (ui : int) =
     if not (0 <= ui && ui < 256) then
-      err (`Not_encodable_as_uint8(ui))
+      failwith "enc fail uint8"
+      (*err (`Not_encodable_as_uint8(ui))*)
     else
       begin
         enc_byte enc (Char.chr ui);

--- a/src/otfm.ml
+++ b/src/otfm.ml
@@ -5960,7 +5960,7 @@ module Encode = struct
                 let priv_start_offset  = fdidx_offset + 0 in
                 let lsubr_start_offset = priv_start_offset + priv_len in
                 let newdictmap         = fix_private_offset priv_len priv_start_offset dictmap in
-                let newpriv            = fix_lsubr_offset (priv_start_offset - lsubr_start_offset) priv in
+                let newpriv            = fix_lsubr_offset (lsubr_start_offset - priv_start_offset) priv in
                 Format.printf "priv:%x lsubr:%x\n%!" priv_start_offset lsubr_start_offset;
                 return (newdictmap, [||], [|newpriv|], lsubrarray)
 
@@ -5997,7 +5997,7 @@ module Encode = struct
                 let newfd = fix_private_offset thispriv_len priv_next_offset fd in
                 let (newpriv, thislsubr_len) =
                   match lsubropt with
-                  | Some(lsubr) -> (fix_lsubr_offset (priv_next_offset - lsubr_next_offset) priv, calculate_subr_index_length lsubr)
+                  | Some(lsubr) -> (fix_lsubr_offset (lsubr_next_offset - priv_next_offset) priv, calculate_subr_index_length lsubr)
                   | None        -> (priv, 0)
                 in
                 let newpair = (newfd, Some(newpriv, lsubropt)) in

--- a/src/otfm.ml
+++ b/src/otfm.ml
@@ -5368,7 +5368,7 @@ module Encode = struct
   let enc_charset_identity enc nGlyphs =
     enc_uint8  enc 2 (* Format 2 *) >>= fun () ->
     enc_uint16 enc 1                >>= fun () ->
-    enc_uint16 enc (nGlyphs - 1)
+    enc_uint16 enc (nGlyphs - 2)
 
 
   let enc_fdselect_format0 enc fdselect =

--- a/src/otfm.ml
+++ b/src/otfm.ml
@@ -5877,7 +5877,7 @@ module Encode = struct
         let offset_private = offset_CFF + reloffset_private in
         seek_pos offset_private d >>= fun () ->
         d_dict size_private d >>= fun dictmap_private ->
-        get_integer_opt dictmap (ShortKey(19)) >>= fun lsubroffopt ->
+        get_integer_opt dictmap_private (ShortKey(19)) >>= fun lsubroffopt ->
         match lsubroffopt with
         | None ->
             return (Some(dictmap_private, None))
@@ -5982,13 +5982,14 @@ module Encode = struct
           in
 
           d_fontdict_private_pair_array offset_CFF dictmap d >>= fun pairarray ->
-          let (fdarray, privarray, _) = extract_pairarray pairarray in
+          let (fdarray, privarray, lsubrarray) = extract_pairarray pairarray in
 
           let fdidx_len          = calculate_index_length_of_array (calculate_encoded_dict_length true) fdarray in
           let priv_len           = sum_of_array (calculate_encoded_dict_length true) privarray in
+          let lsubr_len          = sum_of_array calculate_subr_index_length lsubrarray in
           let priv_start_offset  = fdidx_offset + fdidx_len in
           let lsubr_start_offset = priv_start_offset + priv_len in
-          Format.printf "priv:%x lsubr:%x\n%!" priv_start_offset lsubr_start_offset;
+          Format.printf "priv:%x lsubr:%x end:%x\n%!" priv_start_offset lsubr_start_offset (lsubr_start_offset + lsubr_len);
 
           ignore (pairarray |> Array.fold_left (fun (i, priv_next_offset, lsubr_next_offset) pairopt ->
             match pairopt with
@@ -6014,7 +6015,7 @@ module Encode = struct
 
     ) >>= fun (dictmap, fdarray, privarray, lsubrarray) ->
 
-    Format.printf "lengt of fdarray:%d privarray:%d lsubrarray:%d\n%!"
+    Format.printf "length of fdarray:%d privarray:%d lsubrarray:%d\n%!"
       (Array.length fdarray) (Array.length privarray) (Array.length lsubrarray);
 
     (* Header *)

--- a/src/otfm.ml
+++ b/src/otfm.ml
@@ -6009,7 +6009,7 @@ module Encode = struct
     let stridx_len      = calculate_index_length_of_array String.length stridx in
     let gsubridx_len    = calculate_subr_index_length gsubridx in
     let charset_offset  = header_len + nameidx_len + topdictidx_len + stridx_len + gsubridx_len in
-    let charset_len     = 0 in(*1 + 2 + 2 (* Format 2 *) in*)
+    let charset_len     = 1 + 2 + 2 (* Format 2 *) in
     let fdsel_offset    = charset_offset + charset_len in
     let fdsel_len       =
       match fdselect with
@@ -6129,7 +6129,7 @@ module Encode = struct
     enc_index           enc (enc_charstring_data d)
                           (make_elem_len_pair_of_array get_charstring_length gsubridx) >>= fun () ->
     (* Charsets *)
-    (*enc_charset_identity enc (Array.length glypharr) >>= fun () ->*)
+    enc_charset_identity enc (Array.length glypharr) >>= fun () ->
     (* FDSelect (CIDFonts only) *)
     ( match fdselect with
       | None      -> return ()

--- a/src/otfm.ml
+++ b/src/otfm.ml
@@ -6000,9 +6000,9 @@ module Encode = struct
     (* Header *)
     enc_copy_direct     d enc offset_CFF header_len >>= fun () ->
     (* Name INDEX *)
-    enc_index_singleton enc enc_direct nameidx_len name >>= fun () ->
+    enc_index_singleton enc enc_direct (String.length name) name >>= fun () ->
     (* Top DICT INDEX *)
-    enc_index_singleton enc enc_dict topdictidx_len dictmap >>= fun () ->
+    enc_index_singleton enc enc_dict (calculate_encoded_dict_length dictmap) dictmap >>= fun () ->
     (* String INDEX *)
     enc_index           enc enc_direct (make_elem_len_pair_of_array String.length stridx) >>= fun () ->
     (* Global Subr INDEX *)

--- a/src/otfm.ml
+++ b/src/otfm.ml
@@ -5979,7 +5979,6 @@ module Encode = struct
 
     ) (return (SubrIndexMap.empty)) >>= fun (used_subrs_map : IntSet.t SubrIndexMap.t) ->
 
-    let reduced_len = ref 0 in
     let remove_unused_subrs subrloc subridx =
       match SubrIndexMap.find_opt subrloc used_subrs_map with
       | None -> subridx
@@ -5989,7 +5988,7 @@ module Encode = struct
             if IntSet.mem i used_set then
               (CharStringData(offset, len))
             else
-              (reduced_len := !reduced_len + len; (CharStringData(offset, 0)))
+              (CharStringData(offset, 0))
           )
     in
     let gsubridx = remove_unused_subrs Global gsubridx in

--- a/src/otfm.mli
+++ b/src/otfm.mli
@@ -1006,6 +1006,10 @@ module Encode : sig
 
   type raw_table
 
+  type maxp_version =
+    | TrueTypeVersion
+    | CFFVersion
+
   val make_font_file : raw_table list -> (string, error) result
 
   val empty_cmap : unit -> (raw_table, error) result
@@ -1014,7 +1018,7 @@ module Encode : sig
 
   val hhea : int -> hhea -> (raw_table, error) result
 
-  val maxp : maxp -> (raw_table, error) result
+  val maxp : maxp_version -> maxp -> (raw_table, error) result
 
   type glyph_output_info = {
 

--- a/src/otfm.mli
+++ b/src/otfm.mli
@@ -258,6 +258,7 @@ type error =
   | `Not_encodable_as_int8            of int
   | `Not_encodable_as_uint16          of int
   | `Not_encodable_as_int16           of int
+  | `Not_encodable_as_uint24          of int
   | `Not_encodable_as_uint32          of WideInt.t
   | `Not_encodable_as_int32           of WideInt.t
   | `Not_encodable_as_time            of WideInt.t
@@ -904,8 +905,11 @@ type cff_cid_info =
 
 type charstring_info
 
+type cff_first
+
 type cff_info =
   {
+    cff_first           : cff_first;
     font_name           : string;
     is_fixed_pitch      : bool;
     italic_angle        : int;
@@ -995,7 +999,7 @@ val charstring_bbox : path list -> (csx * csx * csy * csy) option
 
 type raw_glyph
 
-val get_raw_glyph : decoder -> glyph_id -> (raw_glyph option, error) result
+val get_raw_glyph : decoder -> cff_info option -> glyph_id -> (raw_glyph option, error) result
 
 
 module Encode : sig
@@ -1016,8 +1020,6 @@ module Encode : sig
 
   (* -- main table data -- *)
     hmtx : raw_table;
-    glyf : raw_table;
-    loca : raw_table;
 
   (* -- for 'maxp' table -- *)
     number_of_glyphs : int;
@@ -1037,7 +1039,15 @@ module Encode : sig
     number_of_h_metrics    : int;
   }
 
-  val truetype_outline_tables : raw_glyph list -> (glyph_output_info, error) result
+  type glyph_data =
+    | TrueTypeGlyph of raw_table * raw_table
+        (* glyf, loca *)
+    | CFFGlyph      of raw_table
+        (* CFF *)
+
+  val truetype_outline_tables : raw_glyph list -> ((glyph_output_info * glyph_data), error) result
+
+  val cff_outline_tables      : decoder -> cff_info -> raw_glyph list -> ((glyph_output_info * glyph_data), error) result
 
 end
 

--- a/src/otfm.mli
+++ b/src/otfm.mli
@@ -1006,11 +1006,11 @@ module Encode : sig
 
   type raw_table
 
-  type maxp_version =
-    | TrueTypeVersion
-    | CFFVersion
+  type outline_type =
+    | TrueTypeOutline
+    | CFFData
 
-  val make_font_file : raw_table list -> (string, error) result
+  val make_font_file : outline_type -> raw_table list -> (string, error) result
 
   val empty_cmap : unit -> (raw_table, error) result
 
@@ -1018,7 +1018,7 @@ module Encode : sig
 
   val hhea : int -> hhea -> (raw_table, error) result
 
-  val maxp : maxp_version -> maxp -> (raw_table, error) result
+  val maxp : outline_type -> maxp -> (raw_table, error) result
 
   type glyph_output_info = {
 

--- a/test/otfgensubset.ml
+++ b/test/otfgensubset.ml
@@ -63,7 +63,7 @@ let main () =
     | Otfm.TrueTypeCollection(_) -> err (`Msg "unsupported TTC")
   end >>= fun d ->
 
-  OtfSubset.make d gidlst >>= function
+  OtfSubset.make d None(* TrueType *) gidlst >>= function
   | None ->
       print_endline "None";
       return ()


### PR DESCRIPTION
This PR adds a subset embedding support of OpenType CFF fonts to otfm.
This patch includes some encoders for CFF table. To reduce the embedded font size, unnecessary Font DICTs and subroutines are also omitted. 

I tested this patch with lmmono10-regular, [NotoSansCJKjp-Regular](https://github.com/googlei18n/noto-fonts/blob/master/hinted/NotoSansMono-Regular.ttf), [SourceHanSerif-Regular](https://github.com/adobe-fonts/source-han-serif/tree/release/OTF/Japanese), and [OpenType Collection version of SourceHanSerif-Regular](https://github.com/adobe-fonts/source-han-serif/tree/release/OTC).